### PR TITLE
Update readme according to image usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Aeternity builder image
 
-This image is automatically published to DockerHub [`aeternity/builder`](https://hub.docker.com/r/aeternity/builder/). It is meant to be used both as base builder image for [`aeternity/epoch`](https://hub.docker.com/r/aeternity/epoch/) image and as Continuous Integration build executor image.
+This image is automatically published to DockerHub [`aeternity/builder`](https://hub.docker.com/r/aeternity/builder/). It is meant to be used as Continuous Integration build executor image.


### PR DESCRIPTION
The image is not used anymore to build docker image.
That's done by aeternity/infrastructure now.