### PR TITLE
Add Ubuntu 18.04 builder container for Debian/Ubuntu package building (PT-162439780)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ references:
     environment:
       DOCKERHUB_REPO: aeternity/builder
       DOCKER_CLIENT_VERSION: "17.09.0-ce"
+      DOCKERFILE_PATH: "."
 
   setup_remote_docker: &setup_remote_docker
     setup_remote_docker:
@@ -27,7 +28,7 @@ references:
     run:
       name: Build and push Docker image
       command: |
-        docker build -t $DOCKERHUB_REPO:$TAG .
+        docker build -t $DOCKERHUB_REPO:$TAG $DOCKERFILE_PATH
         docker login -u $DOCKER_USER -p $DOCKER_PASS
         docker push $DOCKERHUB_REPO:$TAG
 
@@ -53,7 +54,7 @@ jobs:
           name: Configure docker image tag
           command: |
             echo "export TAG=ci-build-u18-$CIRCLE_BRANCH" >> $BASH_ENV
-            cd package_ubuntu_18.04
+            echo "export DOCKERFILE_PATH=package_ubuntu_18.04" >> $BASH_ENV
       - *build_and_push
 
   deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
       - run:
           name: Configure docker image tag
           command: |
-            echo "export TAG=ci-build-u18-$CIRCLE_BRANCH" >> $BASH_ENV
+            echo "export TAG=1804_deb_pkgs" >> $BASH_ENV
             echo "export DOCKERFILE_PATH=package_ubuntu_18.04" >> $BASH_ENV
       - *build_and_push
 
@@ -83,7 +83,7 @@ workflows:
           requires: []
           filters:
             branches:
-              ignore: master
+              only: master
 
       - deploy:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,12 @@ workflows:
             branches:
               ignore: master
 
+      - build_1804_deb:
+          requires: []
+          filters:
+            branches:
+              ignore: master
+
       - deploy:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,18 @@ jobs:
           command: |
             echo "export TAG=ci-build-$CIRCLE_BRANCH" >> $BASH_ENV
       - *build_and_push
+  build_1804_deb:
+    <<: *container_config
+    steps:
+      - checkout
+      - *setup_remote_docker
+      - *install_docker_client
+      - run:
+          name: Configure docker image tag
+          command: |
+            echo "export TAG=ci-build-u18-$CIRCLE_BRANCH" >> $BASH_ENV
+            cd package_ubuntu_18.04
+      - *build_and_push
 
   deploy:
     <<: *container_config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
           command: |
             echo "export TAG=ci-build-$CIRCLE_BRANCH" >> $BASH_ENV
       - *build_and_push
-  build_1804_deb:
+  build_1804:
     <<: *container_config
     steps:
       - checkout
@@ -53,7 +53,7 @@ jobs:
       - run:
           name: Configure docker image tag
           command: |
-            echo "export TAG=1804_deb_pkgs" >> $BASH_ENV
+            echo "export TAG=1804" >> $BASH_ENV
             echo "export DOCKERFILE_PATH=package_ubuntu_18.04" >> $BASH_ENV
       - *build_and_push
 
@@ -79,7 +79,7 @@ workflows:
             branches:
               ignore: master
 
-      - build_1804_deb:
+      - build_1804:
           requires: []
           filters:
             branches:

--- a/package_ubuntu_18.04/Dockerfile
+++ b/package_ubuntu_18.04/Dockerfile
@@ -1,0 +1,32 @@
+FROM ubuntu:18.04
+
+RUN apt-get -qq update \
+    && apt-get -qq -y install git curl unzip \
+        autoconf build-essential ncurses-dev libssl-dev \
+        python-pip python-dev \
+        default-jre-headless \
+	libsodium-dev debhelper apt-transport-https \
+	autoconf build-essential devscripts erlang \
+	debhelper dh-autoreconf \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV REBAR3_VERSION="3.5.0"
+RUN set -xe \
+    && REBAR3_DOWNLOAD_URL="https://github.com/erlang/rebar3/archive/${REBAR3_VERSION}.tar.gz" \
+    && REBAR3_DOWNLOAD_SHA256="e95e9d1f2ce219f548d4f49ad41409af02069190f19e2b6717585eef6ee77501" \
+    && mkdir -p /usr/src/rebar3-src \
+    && curl -fSL -o rebar3-src.tar.gz "$REBAR3_DOWNLOAD_URL" \
+    && echo "$REBAR3_DOWNLOAD_SHA256 rebar3-src.tar.gz" | sha256sum -c - \
+    && tar -xzf rebar3-src.tar.gz -C /usr/src/rebar3-src --strip-components=1 \
+    && rm rebar3-src.tar.gz \
+    && cd /usr/src/rebar3-src \
+    && HOME=$PWD ./bootstrap \
+    && install -v ./rebar3 /usr/local/bin/ \
+    && rm -rf /usr/src/rebar3-src
+
+RUN pip install virtualenv awscli
+
+# Add non-root user in case some app won't run as root
+RUN useradd --shell /bin/bash builder --create-home
+
+ENV SHELL=/bin/bash


### PR DESCRIPTION
* Added new Dockerfile for 18.04 images.
* Added Debianization tools in new Docker image.
* Added CircleCI config to build and tag the new image.
* New image is only tagged from master always with `1804_deb_pkgs` tag.

The image was tested successfully for *.deb package building.