### PR TITLE
Add license tool

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,7 @@ jobs:
           name: Configure docker image tag
           command: |
             echo "export TAG=ci-build-$CIRCLE_BRANCH" >> $BASH_ENV
+            echo "export DOCKERFILE_PATH=package_ubuntu_18.04" >> $BASH_ENV
       - *build_and_push
 
   build_1604_otp21:

--- a/package_ubuntu_18.04/Dockerfile
+++ b/package_ubuntu_18.04/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get -qq update \
 	libsodium-dev debhelper apt-transport-https \
 	autoconf build-essential devscripts erlang \
 	debhelper dh-autoreconf \
+        ruby-licensee \
     && rm -rf /var/lib/apt/lists/*
 
 ENV REBAR3_VERSION="3.11.1-aeternity.1"


### PR DESCRIPTION
Tool is not available in Ubuntu 16.04.

TODO:
* [ ] Revert CI change.

----

This PR is mainly for not deleting the branch while https://github.com/aeternity/aeternity/pull/2529 considered.