### PR TITLE
Add libgmp-dev to images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get -qq update \
         curl \
         default-jre-headless \
         git \
+        libgmp-dev \
         libssl-dev \
         ncurses-dev \
         python-dev \

--- a/package_ubuntu_18.04/Dockerfile
+++ b/package_ubuntu_18.04/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get -qq update \
         erlang \
         dh-autoreconf \
         git \
+        libgmp-dev \
         libsodium-dev \
         libssl-dev \
         ncurses-dev \


### PR DESCRIPTION
The packages is a dependency of `emcl`.