### PR TITLE
Use the latest stable cimg/ubuntu 18.04 as our base for CI runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   base:
     docker:
-      - image: cimg/base:2021.02
+      - image: cimg/base:stable-18.04
     working_directory: ~/builder
     environment:
       DOCKERHUB_REPO: aeternity/builder


### PR DESCRIPTION
This PR was sponsored by the ACF