### PR TITLE
Switch to bionic as our default build - first step to remove xenial

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ jobs:
       - checkout
       - use_remote_docker
       - build_and_push:
-          dockerfile: Dockerfile-xenial
+          dockerfile: Dockerfile-bionic
           otp_version: "22.3.4.9"
           tag: latest
 


### PR DESCRIPTION
Step one - default is used in a bunch of our repos including mnesia_rocksdb. This should allow them to build again

Next step would be to remove all the various places that use xenial builds

Finally we can remove xenial from this repo

This PR is sponsored by the ACF