### PR TITLE
Multi-platform support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,10 +16,15 @@ executors:
     docker:
       - image: cimg/base:stable-18.04
     working_directory: ~/builder
-  buildx:
+  amd64:
     docker:
       - image: cimg/base:stable
     resource_class: xlarge
+    working_directory: /home/circleci/aeternity
+  arm64:
+    docker:
+      - image: cimg/base:stable
+    resource_class: arm.2xlarge
     working_directory: /home/circleci/aeternity
 
 commands:
@@ -108,8 +113,11 @@ commands:
 
 jobs:
   build_and_push:
-    executor: base
+    executor: << parameters.platform >>
     parameters:
+      platform:
+        type: string
+        default: amd64
       distro:
         type: string
       otp_version:
@@ -129,7 +137,7 @@ jobs:
           tag: << parameters.tag >>
           latest: << parameters.latest >>
   buildx_and_push:
-    executor: buildx
+    executor: amd64
     parameters:
       distro:
         type: string
@@ -154,11 +162,23 @@ workflows:
   version: 2
   commit:
     jobs:
-      - buildx_and_push:
-          name: "build_1804_otp23"
+      - build_and_push:
+          name: "build_1804_otp23_amd64"
+          platform: amd64
           distro: "bionic"
           otp_version: "23.3.4.5"
-          tag: ci-bionic-otp23-<< pipeline.git.branch >>
+          tag: ci-bionic-otp23-amd64-<< pipeline.git.branch >>
+          context: ae-dockerhub
+          requires: []
+          filters:
+            branches:
+              ignore: master
+      - build_and_push:
+          name: "build_1804_otp23_arm64"
+          platform: arm64
+          distro: "bionic"
+          otp_version: "23.3.4.5"
+          tag: ci-bionic-otp23-arm64-<< pipeline.git.branch >>
           context: ae-dockerhub
           requires: []
           filters:
@@ -169,6 +189,16 @@ workflows:
           distro: "focal"
           otp_version: "23.3.4.5"
           tag: ci-focal-otp23-<< pipeline.git.branch >>
+          context: ae-dockerhub
+          requires: []
+          filters:
+            branches:
+              ignore: master
+      - buildx_and_push:
+          name: "build_2204_otp23"
+          distro: "jammy"
+          otp_version: "23.3.4.5"
+          tag: ci-jammy-otp23-<< pipeline.git.branch >>
           context: ae-dockerhub
           requires: []
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ commands:
             docker buildx install
             docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
             docker context create aeternity
-            docker buildx create --use --platform $BUILDX_PLATFORMS aeternity
+            docker buildx create --use --platform << pipeline.parameters.buildx_platforms >> aeternity
             docker buildx inspect --builder aeternity --bootstrap
       - unless:
           condition: << parameters.latest >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ commands:
   use_remote_docker:
     steps:
       - setup_remote_docker:
-          docker_layer_caching: true
+          # docker_layer_caching: true
           version: "20.10.11"
   build_and_push:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,52 +187,54 @@ workflows:
   version: 2
   commit:
     jobs:
-      - docker_manifest:
-          name: "manifest_test"
-          manifest_list: >-
-            ci-bionic-otp23-amd64-<< pipeline.git.branch >>
-            ci-bionic-otp23-arm64-<< pipeline.git.branch >>
-          tag: ci-bionic-otp23-<< pipeline.git.branch >>
+      - build_and_push:
+          name: "build_1804_otp23_amd64"
+          platform: amd64
+          distro: "bionic"
+          otp_version: "23.3.4.5"
+          tag: ci-bionic-otp23-arm64-<< pipeline.git.branch >>
           context: ae-dockerhub
           requires: []
           filters:
             branches:
               ignore: master
 
-      # - build_and_push:
-      #     name: "build_1804_otp23_amd64"
-      #     platform: amd64
-      #     distro: "bionic"
-      #     otp_version: "23.3.4.5"
-      #     tag: ci-bionic-otp23-arm64-<< pipeline.git.branch >>
-      #     context: ae-dockerhub
-      #     requires: []
-      #     filters:
-      #       branches:
-      #         ignore: master
+      - build_and_push:
+          name: "build_1804_otp23_arm64"
+          platform: arm64
+          distro: "bionic"
+          otp_version: "23.3.4.5"
+          tag: ci-bionic-otp23-arm64-<< pipeline.git.branch >>
+          context: ae-dockerhub
+          requires: []
+          filters:
+            branches:
+              ignore: master
 
-      # - build_and_push:
-      #     name: "build_1804_otp23_arm64"
-      #     platform: arm64
-      #     distro: "bionic"
-      #     otp_version: "23.3.4.5"
-      #     tag: ci-bionic-otp23-arm64-<< pipeline.git.branch >>
-      #     context: ae-dockerhub
-      #     requires: []
-      #     filters:
-      #       branches:
-      #         ignore: master
+      - docker_manifest:
+          name: "manifest_push"
+          manifest_list: >-
+            ci-bionic-otp23-amd64-<< pipeline.git.branch >>
+            ci-bionic-otp23-arm64-<< pipeline.git.branch >>
+          tag: ci-bionic-otp23-<< pipeline.git.branch >>
+          context: ae-dockerhub
+          requires:
+            - build_1804_otp23_amd64
+            - build_1804_otp23_arm64
+          filters:
+            branches:
+              ignore: master
 
-      # - build_and_push:
-      #     name: "build_2004_otp23"
-      #     distro: "focal"
-      #     otp_version: "23.3.4.5"
-      #     tag: ci-focal-otp23-<< pipeline.git.branch >>
-      #     context: ae-dockerhub
-      #     requires: []
-      #     filters:
-      #       branches:
-      #         ignore: master
+      - build_and_push:
+          name: "build_2004_otp23"
+          distro: "focal"
+          otp_version: "23.3.4.5"
+          tag: ci-focal-otp23-<< pipeline.git.branch >>
+          context: ae-dockerhub
+          requires: []
+          filters:
+            branches:
+              ignore: master
 
   release:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,18 +15,15 @@ executors:
   amd64:
     machine:
       image: ubuntu-2004:current
+      docker_layer_caching: true
     resource_class: xlarge
   arm64:
     machine:
       image: ubuntu-2004:current
+      docker_layer_caching: true
     resource_class: arm.xlarge
 
 commands:
-  use_remote_docker:
-    steps:
-      - setup_remote_docker:
-          # docker_layer_caching: true
-          version: "20.10.18"
   build_and_push:
     parameters:
       dockerfile:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ executors:
   amd64:
     machine:
       image: ubuntu-2004:current
-    resource_class: xlarge
+    # resource_class: xlarge
   arm64:
     machine:
       image: ubuntu-2004:current

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,31 @@ commands:
                     --build-arg BUILD_OTP_VERSION=<< parameters.otp_version >> \
                     - < << parameters.dockerfile >>
 
+  docker_manifest:
+    parameters:
+      manifest_list:
+        type: string
+      tag:
+        type: string
+    steps:
+      - run:
+          name: Create docker manifest
+          command: |
+            read -a MANIFEST_LIST_ARRAY \<<< "<< parameters.manifest_list >>"
+            PREFIX="<< pipeline.parameters.docker_repo >>:"
+            MANIFEST_LIST="${MANIFEST_LIST_ARRAY[@]/#/$PREFIX}"
+            docker manifest create \
+              << pipeline.parameters.docker_repo >>:<< parameters.tag >> \
+              $MANIFEST_LIST
+      - run:
+          name: Login to docker.io registry
+          command: |
+            docker login -u $DOCKER_USER -p $DOCKER_PASS
+      - run:
+          name: Push docker manifest
+          command: |
+            docker manifest push << pipeline.parameters.docker_repo >>:<< parameters.tag >>
+
 jobs:
   build_and_push:
     executor: << parameters.platform >>
@@ -146,15 +171,27 @@ jobs:
           otp_version: << parameters.otp_version >>
           tag: << parameters.tag >>
           latest: << parameters.latest >>
+  docker_manifest:
+    executor: amd64
+    parameters:
+      manifest_list:
+        type: string
+      tag:
+        type: string
+    steps:
+      - docker_manifest:
+          manifest_list: << parameters.manifest_list >>
+          tag: << parameters.tag >>
 
 workflows:
   version: 2
   commit:
     jobs:
-      - buildx_and_push:
-          name: "build_1804_otp23"
-          distro: "bionic"
-          otp_version: "23.3.4.5"
+      - docker_manifest:
+          name: "manifest_test"
+          manifest_list: >-
+            ci-bionic-otp23-amd64-<< pipeline.git.branch >>
+            ci-bionic-otp23-arm64-<< pipeline.git.branch >>
           tag: ci-bionic-otp23-<< pipeline.git.branch >>
           context: ae-dockerhub
           requires: []
@@ -162,16 +199,40 @@ workflows:
             branches:
               ignore: master
 
-      - build_and_push:
-          name: "build_2004_otp23"
-          distro: "focal"
-          otp_version: "23.3.4.5"
-          tag: ci-focal-otp23-<< pipeline.git.branch >>
-          context: ae-dockerhub
-          requires: []
-          filters:
-            branches:
-              ignore: master
+      # - build_and_push:
+      #     name: "build_1804_otp23_amd64"
+      #     platform: amd64
+      #     distro: "bionic"
+      #     otp_version: "23.3.4.5"
+      #     tag: ci-bionic-otp23-arm64-<< pipeline.git.branch >>
+      #     context: ae-dockerhub
+      #     requires: []
+      #     filters:
+      #       branches:
+      #         ignore: master
+
+      # - build_and_push:
+      #     name: "build_1804_otp23_arm64"
+      #     platform: arm64
+      #     distro: "bionic"
+      #     otp_version: "23.3.4.5"
+      #     tag: ci-bionic-otp23-arm64-<< pipeline.git.branch >>
+      #     context: ae-dockerhub
+      #     requires: []
+      #     filters:
+      #       branches:
+      #         ignore: master
+
+      # - build_and_push:
+      #     name: "build_2004_otp23"
+      #     distro: "focal"
+      #     otp_version: "23.3.4.5"
+      #     tag: ci-focal-otp23-<< pipeline.git.branch >>
+      #     context: ae-dockerhub
+      #     requires: []
+      #     filters:
+      #       branches:
+      #         ignore: master
 
   release:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,14 @@ commands:
           name: Login to docker.io registry
           command: |
             docker login -u $DOCKER_USER -p $DOCKER_PASS
+      - run:
+          name: Setup buildx
+          command: |
+            docker buildx install
+            docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+            docker context create aeternity
+            docker buildx create --use --platform $BUILDX_PLATFORMS aeternity
+            docker buildx inspect --builder aeternity --bootstrap
       - unless:
           condition: << parameters.latest >>
           steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ executors:
   amd64:
     machine:
       image: ubuntu-2004:current
-    # resource_class: xlarge
+    resource_class: xlarge
   arm64:
     machine:
       image: ubuntu-2004:current

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,18 +12,14 @@ parameters:
     default: linux/arm64,linux/amd64
 
 executors:
-  base:
-    docker:
-      - image: cimg/base:stable-18.04
-    working_directory: ~/builder
   amd64:
-    docker:
-      - image: cimg/base:stable
+    machine:
+      image: ubuntu-2004:current
     resource_class: xlarge
     working_directory: /home/circleci/aeternity
   arm64:
-    docker:
-      - image: cimg/base:stable
+    machine:
+      image: ubuntu-2004:current
     resource_class: arm.xlarge
     working_directory: /home/circleci/aeternity
 
@@ -130,7 +126,6 @@ jobs:
         default: false
     steps:
       - checkout
-      - use_remote_docker
       - build_and_push:
           dockerfile: Dockerfile-<< parameters.distro >>
           otp_version: << parameters.otp_version >>
@@ -151,7 +146,6 @@ jobs:
         default: false
     steps:
       - checkout
-      - use_remote_docker
       - buildx_and_push:
           dockerfile: Dockerfile-<< parameters.distro >>
           otp_version: << parameters.otp_version >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ executors:
       DOCKER_CLIENT_VERSION: "20.10.11"
       DOCKERFILE_PATH: "."
       DOCKER_CLI_EXPERIMENTAL: "enabled"
-      BUILDX_PLATFORMS: linux/amd64,linux/arm64
+      BUILDX_PLATFORMS: linux/arm64,linux/amd64
 
 commands:
   use_remote_docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,9 @@
 version: 2.1
 
 parameters:
-  buildx-version:
-    type: string
-    default: "0.10.0"
   docker_repo:
     type: string
     default: aeternity/builder
-  buildx_platforms:
-    type: string
-    default: linux/arm64,linux/amd64
 
 executors:
   amd64:
@@ -54,53 +48,6 @@ commands:
                 command: |
                   docker tag << pipeline.parameters.docker_repo >>:<< parameters.tag >> << pipeline.parameters.docker_repo >>:latest
                   docker push << pipeline.parameters.docker_repo >>:latest
-  buildx_and_push:
-    parameters:
-      dockerfile:
-        type: string
-      otp_version:
-        type: string
-      tag:
-        type: string
-      latest:
-        type: boolean
-        default: false
-    steps:
-      - run:
-          name: Login to docker.io registry
-          command: |
-            docker login -u $DOCKER_USER -p $DOCKER_PASS
-      - run:
-          name: Setup buildx
-          command: |
-            docker buildx install
-            docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-            docker context create aeternity
-            docker buildx create --use --platform << pipeline.parameters.buildx_platforms >> aeternity
-            docker buildx inspect --builder aeternity --bootstrap
-      - unless:
-          condition: << parameters.latest >>
-          steps:
-            - run:
-                name: Build and push docker image to docker.io registry
-                command: |
-                  docker buildx build --progress=plain --push \
-                    -t << pipeline.parameters.docker_repo >>:<< parameters.tag >> \
-                    --platform << pipeline.parameters.buildx_platforms >> \
-                    --build-arg BUILD_OTP_VERSION=<< parameters.otp_version >> \
-                    - < << parameters.dockerfile >>
-      - when:
-          condition: << parameters.latest >>
-          steps:
-            - run:
-                name: Build and push docker image to docker.io registry
-                command: |
-                  docker buildx build --progress=plain --push \
-                    -t << pipeline.parameters.docker_repo >>:<< parameters.tag >> \
-                    -t << pipeline.parameters.docker_repo >>:latest \
-                    --platform << pipeline.parameters.buildx_platforms >> \
-                    --build-arg BUILD_OTP_VERSION=<< parameters.otp_version >> \
-                    - < << parameters.dockerfile >>
 
   docker_manifest:
     parameters:
@@ -151,26 +98,6 @@ jobs:
           otp_version: << parameters.otp_version >>
           tag: << parameters.tag >>
           latest: << parameters.latest >>
-  buildx_and_push:
-    executor: amd64
-    parameters:
-      distro:
-        type: string
-      otp_version:
-        type: string
-      tag:
-        type: string
-        default: bionic-otp23
-      latest:
-        type: boolean
-        default: false
-    steps:
-      - checkout
-      - buildx_and_push:
-          dockerfile: Dockerfile-<< parameters.distro >>
-          otp_version: << parameters.otp_version >>
-          tag: << parameters.tag >>
-          latest: << parameters.latest >>
   docker_manifest:
     executor: amd64
     parameters:
@@ -212,7 +139,7 @@ workflows:
               ignore: master
 
       - docker_manifest:
-          name: "manifest_push_1804_otp23"
+          name: "build_manifest_bionic_otp23"
           manifest_list: >-
             ci-bionic-otp23-amd64-<< pipeline.git.branch >>
             ci-bionic-otp23-arm64-<< pipeline.git.branch >>
@@ -238,14 +165,54 @@ workflows:
 
   release:
     jobs:
-      - buildx_and_push:
-          name: "release_1804_otp23"
+      - build_and_push:
+          platform: amd64
+          name: "release_1804_otp23_amd64"
           distro: "bionic"
           otp_version: "23.3.4.5"
-          tag: "bionic-otp23"
-          latest: true
+          tag: "bionic-otp23-amd64"
           context: ae-dockerhub
           requires: []
+          filters:
+            branches:
+              only: master
+
+      - build_and_push:
+          name: "release_1804_otp23_arm64"
+          platform: arm64
+          distro: "bionic"
+          otp_version: "23.3.4.5"
+          tag: "bionic-otp23-arm64"
+          context: ae-dockerhub
+          requires: []
+          filters:
+            branches:
+              only: master
+
+      - docker_manifest:
+          name: "release_manifest_bionic_otp23"
+          manifest_list: >-
+            bionic-otp23-amd64
+            bionic-otp23-arm64
+          tag: bionic-otp23
+          context: ae-dockerhub
+          requires:
+            - release_1804_otp23_amd64
+            - release_1804_otp23_arm64
+          filters:
+            branches:
+              only: master
+
+      - docker_manifest:
+          name: "release_manifest_latest"
+          manifest_list: >-
+            bionic-otp23-amd64
+            bionic-otp23-arm64
+          tag: latest
+          context: ae-dockerhub
+          requires:
+            - release_1804_otp23_amd64
+            - release_1804_otp23_arm64
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,7 +174,7 @@ workflows:
   version: 2
   commit:
     jobs:
-      - build_and_push:
+      - buildx_and_push:
           name: "build_1804_otp23"
           distro: "bionic"
           otp_version: "23.3.4.5"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,6 +135,7 @@ jobs:
         default: false
     steps:
       - checkout
+      - use_remote_docker
       - buildx_and_push:
           dockerfile: Dockerfile-<< parameters.distro >>
           otp_version: << parameters.otp_version >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,28 +154,17 @@ workflows:
   version: 2
   commit:
     jobs:
-      - build_and_push:
-          name: "build_1804_otp23_amd64"
-          platform: amd64
+      - buildx_and_push:
+          name: "build_1804_otp23"
           distro: "bionic"
           otp_version: "23.3.4.5"
-          tag: ci-bionic-otp23-amd64-<< pipeline.git.branch >>
+          tag: ci-bionic-otp23-<< pipeline.git.branch >>
           context: ae-dockerhub
           requires: []
           filters:
             branches:
               ignore: master
-      - build_and_push:
-          name: "build_1804_otp23_arm64"
-          platform: arm64
-          distro: "bionic"
-          otp_version: "23.3.4.5"
-          tag: ci-bionic-otp23-arm64-<< pipeline.git.branch >>
-          context: ae-dockerhub
-          requires: []
-          filters:
-            branches:
-              ignore: master
+
       - build_and_push:
           name: "build_2004_otp23"
           distro: "focal"
@@ -186,21 +175,11 @@ workflows:
           filters:
             branches:
               ignore: master
-      - buildx_and_push:
-          name: "build_2204_otp23"
-          distro: "jammy"
-          otp_version: "23.3.4.5"
-          tag: ci-jammy-otp23-<< pipeline.git.branch >>
-          context: ae-dockerhub
-          requires: []
-          filters:
-            branches:
-              ignore: master
 
   release:
     jobs:
-      - build_and_push:
-          name: "build_1804_otp23"
+      - buildx_and_push:
+          name: "release_1804_otp23"
           distro: "bionic"
           otp_version: "23.3.4.5"
           tag: "bionic-otp23"
@@ -212,7 +191,7 @@ workflows:
               only: master
 
       - build_and_push:
-          name: "build_1804_otp24"
+          name: "release_1804_otp24"
           distro: "bionic"
           otp_version: "24.1.3"
           tag: "bionic-otp24"
@@ -223,7 +202,7 @@ workflows:
               only: master
 
       - build_and_push:
-          name: "build_2004_otp23"
+          name: "release_2004_otp23"
           distro: "focal"
           otp_version: "23.3.4.5"
           tag: "focal-otp23"
@@ -234,7 +213,7 @@ workflows:
               only: master
 
       - build_and_push:
-          name: "build_2004_otp24"
+          name: "release_2004_otp24"
           distro: "focal"
           otp_version: "24.1.3"
           tag: "focal-otp24"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   buildx-version:
     type: string
-    default: "0.7.0"
+    default: "0.10.0"
 
 executors:
   base:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ parameters:
     default: "0.10.0"
   docker_repo:
     type: string
-    default: aeternity/aeternity
+    default: aeternity/builder
   buildx_platforms:
     type: string
     default: linux/arm64,linux/amd64
@@ -16,12 +16,10 @@ executors:
     machine:
       image: ubuntu-2004:current
     resource_class: xlarge
-    working_directory: /home/circleci/aeternity
   arm64:
     machine:
       image: ubuntu-2004:current
     resource_class: arm.xlarge
-    working_directory: /home/circleci/aeternity
 
 commands:
   use_remote_docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,7 +192,7 @@ workflows:
           platform: amd64
           distro: "bionic"
           otp_version: "23.3.4.5"
-          tag: ci-bionic-otp23-arm64-<< pipeline.git.branch >>
+          tag: ci-bionic-otp23-amd64-<< pipeline.git.branch >>
           context: ae-dockerhub
           requires: []
           filters:
@@ -212,7 +212,7 @@ workflows:
               ignore: master
 
       - docker_manifest:
-          name: "manifest_push"
+          name: "manifest_push_1804_otp23"
           manifest_list: >-
             ci-bionic-otp23-amd64-<< pipeline.git.branch >>
             ci-bionic-otp23-arm64-<< pipeline.git.branch >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ executors:
   arm64:
     docker:
       - image: cimg/base:stable
-    resource_class: arm.2xlarge
+    resource_class: arm.xlarge
     working_directory: /home/circleci/aeternity
 
 commands:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,34 +4,30 @@ parameters:
   buildx-version:
     type: string
     default: "0.10.0"
+  docker_repo:
+    type: string
+    default: aeternity/aeternity
+  buildx_platforms:
+    type: string
+    default: linux/arm64,linux/amd64
 
 executors:
   base:
     docker:
       - image: cimg/base:stable-18.04
     working_directory: ~/builder
-    environment:
-      DOCKERHUB_REPO: aeternity/builder
-      DOCKER_CLIENT_VERSION: "17.09.0-ce"
-      DOCKERFILE_PATH: "."
   buildx:
-    machine:
-      image: ubuntu-2004:current
-      resource_class: xlarge
-    working_directory: ~/builder
-    environment:
-      DOCKERHUB_REPO: aeternity/builder
-      DOCKER_CLIENT_VERSION: "20.10.11"
-      DOCKERFILE_PATH: "."
-      DOCKER_CLI_EXPERIMENTAL: "enabled"
-      BUILDX_PLATFORMS: linux/arm64,linux/amd64
+    docker:
+      - image: cimg/base:stable
+    resource_class: xlarge
+    working_directory: /home/circleci/aeternity
 
 commands:
   use_remote_docker:
     steps:
       - setup_remote_docker:
           # docker_layer_caching: true
-          version: "20.10.11"
+          version: "20.10.18"
   build_and_push:
     parameters:
       dockerfile:
@@ -47,21 +43,21 @@ commands:
       - run:
           name: Build Docker image
           command: |
-            docker build -t $DOCKERHUB_REPO:<< parameters.tag >> \
+            docker build -t << pipeline.parameters.docker_repo >>:<< parameters.tag >> \
               --build-arg BUILD_OTP_VERSION=<< parameters.otp_version >> - < << parameters.dockerfile >>
       - run:
           name: Push Docker image to docker.io registry
           command: |
             docker login -u $DOCKER_USER -p $DOCKER_PASS
-            docker push $DOCKERHUB_REPO:<< parameters.tag >>
+            docker push << pipeline.parameters.docker_repo >>:<< parameters.tag >>
       - when:
           condition: << parameters.latest >>
           steps:
             - run:
                 name: Tag and push latest
                 command: |
-                  docker tag $DOCKERHUB_REPO:<< parameters.tag >> $DOCKERHUB_REPO:latest
-                  docker push $DOCKERHUB_REPO:latest
+                  docker tag << pipeline.parameters.docker_repo >>:<< parameters.tag >> << pipeline.parameters.docker_repo >>:latest
+                  docker push << pipeline.parameters.docker_repo >>:latest
   buildx_and_push:
     parameters:
       dockerfile:
@@ -75,27 +71,6 @@ commands:
         default: false
     steps:
       - run:
-          name: Install emulation dependencies
-          command: |
-            sudo apt-get update && sudo apt-get install -y qemu binfmt-support qemu-user-static
-      - run:
-          name: Install buildx
-          command: |
-            mkdir -p ~/.docker/cli-plugins
-            baseUrl="https://github.com/docker/buildx/releases/download"
-            fileName="buildx-v<< pipeline.parameters.buildx-version >>.linux-amd64"
-            url="${baseUrl}/v<< pipeline.parameters.buildx-version >>/${fileName}"
-            curl -sSL -o ~/.docker/cli-plugins/docker-buildx $url
-            chmod a+x ~/.docker/cli-plugins/docker-buildx
-      - run:
-          name: Setup buildx
-          command: |
-            docker buildx install
-            docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-            docker context create aeternity
-            docker buildx create --use --platform $BUILDX_PLATFORMS aeternity
-            docker buildx inspect --builder aeternity --bootstrap
-      - run:
           name: Login to docker.io registry
           command: |
             docker login -u $DOCKER_USER -p $DOCKER_PASS
@@ -104,12 +79,10 @@ commands:
           steps:
             - run:
                 name: Build and push docker image to docker.io registry
-                environment:
-                  DOCKER_CLI_EXPERIMENTAL: enabled
                 command: |
                   docker buildx build --progress=plain --push \
-                    -t $DOCKERHUB_REPO:<< parameters.tag >> \
-                    --platform $BUILDX_PLATFORMS \
+                    -t << pipeline.parameters.docker_repo >>:<< parameters.tag >> \
+                    --platform << pipeline.parameters.buildx_platforms >> \
                     --build-arg BUILD_OTP_VERSION=<< parameters.otp_version >> \
                     - < << parameters.dockerfile >>
       - when:
@@ -117,13 +90,11 @@ commands:
           steps:
             - run:
                 name: Build and push docker image to docker.io registry
-                environment:
-                  DOCKER_CLI_EXPERIMENTAL: enabled
                 command: |
                   docker buildx build --progress=plain --push \
-                    -t $DOCKERHUB_REPO:<< parameters.tag >> \
-                    -t $DOCKERHUB_REPO:latest \
-                    --platform $BUILDX_PLATFORMS \
+                    -t << pipeline.parameters.docker_repo >>:<< parameters.tag >> \
+                    -t << pipeline.parameters.docker_repo >>:latest \
+                    --platform << pipeline.parameters.buildx_platforms >> \
                     --build-arg BUILD_OTP_VERSION=<< parameters.otp_version >> \
                     - < << parameters.dockerfile >>
 

--- a/Dockerfile-bionic
+++ b/Dockerfile-bionic
@@ -1,5 +1,7 @@
 FROM ubuntu:18.04
 
+RUN echo "I'm building for $TARGETARCH"
+
 RUN apt-get -qq update \
     && apt-get -qq -y install \
         apt-transport-https \

--- a/Dockerfile-bionic
+++ b/Dockerfile-bionic
@@ -1,7 +1,5 @@
 FROM ubuntu:18.04
 
-RUN echo "I'm building for $TARGETARCH"
-
 RUN apt-get -qq update \
     && apt-get -qq -y install \
         apt-transport-https \

--- a/Dockerfile-bionic
+++ b/Dockerfile-bionic
@@ -37,6 +37,7 @@ RUN PACKAGE_NAME=esl-erlang_${OTP_VERSION}-1~ubuntu~bionic_$(dpkg --print-archit
     && dpkg -i ${PACKAGE_NAME} \
     && rm esl-erlang_${OTP_VERSION}-1~ubuntu~bionic_$(dpkg --print-architecture).deb
 
+ENV PORTABLE=1
 ENV ROCKSDB_VERSION=6.13.3
 RUN set -xe \
     && ROCKSDB_DOWNLOAD_URL="https://github.com/facebook/rocksdb/archive/v${ROCKSDB_VERSION}.tar.gz" \

--- a/Dockerfile-focal
+++ b/Dockerfile-focal
@@ -38,6 +38,7 @@ RUN PACKAGE_NAME=esl-erlang_${OTP_VERSION}-1~ubuntu~focal_$(dpkg --print-archite
     && dpkg -i ${PACKAGE_NAME} \
     && rm esl-erlang_${OTP_VERSION}-1~ubuntu~focal_$(dpkg --print-architecture).deb
 
+ENV PORTABLE=1
 ENV ROCKSDB_VERSION=6.13.3
 RUN set -xe \
     && ROCKSDB_DOWNLOAD_URL="https://github.com/facebook/rocksdb/archive/v${ROCKSDB_VERSION}.tar.gz" \


### PR DESCRIPTION
- switch to **portable** rocksdb lib to make it possible to run on non AVX512 hosts
- build multi-platform Bionic OTP23 builder images
- keep other images Intel only to safe time and effort
- drop usage of buildx and use separate platform builds + docker manifest merge

Sample docker builder image can be tested as `aeternity/builder:ci-bionic-otp23-buildx`
A test node image build with that builder can be tested as `aeternity/aeternity:arm`