### PR TITLE
Remove predefined UID 1000 in Ubuntu 24 image

### DIFF
--- a/Dockerfile-noble
+++ b/Dockerfile-noble
@@ -64,6 +64,9 @@ RUN set -xe \
     && install -v ./rebar3 /usr/local/bin/ \
     && rm -rf /usr/src/rebar3-src
 
+# Remove the default Ubuntu user (freeing UID 1000)
+RUN userdel -f ubuntu
+
 # Add non-root user in case some app won't run as root
 RUN useradd --shell /bin/bash builder --create-home
 


### PR DESCRIPTION
Need to remove the Ubuntu 24 base image user, otherwise the builder user gets UID 1001, causing file permission problems on Linux.