### PR TITLE
Bump rebar3 version in containers to 3.24.0

### DIFF
--- a/Dockerfile-focal
+++ b/Dockerfile-focal
@@ -52,10 +52,10 @@ RUN set -xe \
     && cd rocksdb-src \
     && make shared_lib && make install-shared && ldconfig
 
-ENV REBAR3_VERSION="3.17.0"
+ENV REBAR3_VERSION="3.24.0"
 RUN set -xe \
     && REBAR3_DOWNLOAD_URL="https://github.com/erlang/rebar3/archive/${REBAR3_VERSION}.tar.gz" \
-    && REBAR3_DOWNLOAD_SHA256="4c7f33a342bcab498f9bf53cc0ee5b698d9598b8fa9ef6a14bcdf44d21945c27" \
+    && REBAR3_DOWNLOAD_SHA256="391b0eaa2825bb427fef1e55a0d166493059175f57a33b00346b84a20398216c" \
     && mkdir -p /usr/src/rebar3-src \
     && curl -fSL -o rebar3-src.tar.gz "$REBAR3_DOWNLOAD_URL" \
     && echo "$REBAR3_DOWNLOAD_SHA256 rebar3-src.tar.gz" | sha256sum -c - \

--- a/Dockerfile-jammy
+++ b/Dockerfile-jammy
@@ -52,10 +52,10 @@ RUN set -xe \
     && cd rocksdb-src \
     && make shared_lib && make install-shared && ldconfig
 
-ENV REBAR3_VERSION="3.17.0"
+ENV REBAR3_VERSION="3.24.0"
 RUN set -xe \
     && REBAR3_DOWNLOAD_URL="https://github.com/erlang/rebar3/archive/${REBAR3_VERSION}.tar.gz" \
-    && REBAR3_DOWNLOAD_SHA256="4c7f33a342bcab498f9bf53cc0ee5b698d9598b8fa9ef6a14bcdf44d21945c27" \
+    && REBAR3_DOWNLOAD_SHA256="391b0eaa2825bb427fef1e55a0d166493059175f57a33b00346b84a20398216c" \
     && mkdir -p /usr/src/rebar3-src \
     && curl -fSL -o rebar3-src.tar.gz "$REBAR3_DOWNLOAD_URL" \
     && echo "$REBAR3_DOWNLOAD_SHA256 rebar3-src.tar.gz" | sha256sum -c - \

--- a/Dockerfile-noble
+++ b/Dockerfile-noble
@@ -50,10 +50,10 @@ RUN set -xe \
     && cd rocksdb-src \
     && make shared_lib && make install-shared && ldconfig
 
-ENV REBAR3_VERSION="3.17.0"
+ENV REBAR3_VERSION="3.24.0"
 RUN set -xe \
     && REBAR3_DOWNLOAD_URL="https://github.com/erlang/rebar3/archive/${REBAR3_VERSION}.tar.gz" \
-    && REBAR3_DOWNLOAD_SHA256="4c7f33a342bcab498f9bf53cc0ee5b698d9598b8fa9ef6a14bcdf44d21945c27" \
+    && REBAR3_DOWNLOAD_SHA256="391b0eaa2825bb427fef1e55a0d166493059175f57a33b00346b84a20398216c" \
     && mkdir -p /usr/src/rebar3-src \
     && curl -fSL -o rebar3-src.tar.gz "$REBAR3_DOWNLOAD_URL" \
     && echo "$REBAR3_DOWNLOAD_SHA256 rebar3-src.tar.gz" | sha256sum -c - \


### PR DESCRIPTION
This matches the version checked in to the aeternity master branch.